### PR TITLE
Add initialized Type::array and Type::object tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -130,4 +130,4 @@ jobs:
         run: $(which composer) install --no-interaction --no-progress --no-suggest
 
       - name: "Run tests with phpunit/phpunit"
-        run: bin/phpunit
+        run: vendor/bin/phpunit

--- a/test/TypeProvider.php
+++ b/test/TypeProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BackEndTea\Assert\Test;
 
 use Generator;
+use stdClass;
 use const INF;
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
@@ -88,5 +89,35 @@ final class TypeProvider
         yield [-12.0];
         yield [16.2];
         yield [18.0];
+    }
+
+    /**
+     * @return Generator<array<mixed>>
+     */
+    public static function array(): Generator
+    {
+        yield [
+            [1.7],
+            [true],
+            [false],
+            ['1.7'],
+        ];
+
+        yield [
+            ['0.0', '1.7'],
+            [INF, PHP_INT_MAX, PHP_INT_MIN],
+        ];
+
+        yield [
+            [new stdClass(), '0.0', 'TEST_ARRAY'],
+        ];
+    }
+
+    /**
+     * @return Generator<array<object>>
+     */
+    public static function object(): Generator
+    {
+        yield [new stdClass()];
     }
 }

--- a/test/TypeTest.php
+++ b/test/TypeTest.php
@@ -81,4 +81,59 @@ final class TypeTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $call($input);
     }
+
+    /**
+     * @param mixed $array
+     *
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::array()
+     */
+    public function testArray($array): void
+    {
+        $this->assertSame($array, Type::array()($array));
+    }
+
+    /**
+     * @param mixed $input
+     *
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::int()
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::string()
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::null()
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::float()
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::bool()
+     */
+    public function testNotArray($input): void
+    {
+        $call = Type::array();
+
+        $this->expectException(InvalidArgumentException::class);
+        $call($input);
+    }
+
+    /**
+     * @param mixed $object
+     *
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::object()
+     */
+    public function testObject($object): void
+    {
+        $this->assertSame($object, Type::object()($object));
+    }
+
+    /**
+     * @param mixed $input
+     *
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::int()
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::string()
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::null()
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::float()
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::bool()
+     * @dataProvider \BackEndTea\Assert\Test\TypeProvider::array()
+     */
+    public function testNotObject($input): void
+    {
+        $call = Type::object();
+
+        $this->expectException(InvalidArgumentException::class);
+        $call($input);
+    }
 }


### PR DESCRIPTION
# Changed log
- Add initialized `Type::array` and `Type::object` tests with `PHPUnit`.
- Fix GitHub Action.